### PR TITLE
Allow cms version 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 	},
 	"require": {
 		"luyadev/luya-core" : "^1.0",
-		"luyadev/luya-module-cms": "^1.0",
+		"luyadev/luya-module-cms": "^1.0||^2.0",
 		"samdark/sitemap": "^2.0"
 	},
 	"require-dev" : {


### PR DESCRIPTION
Allow version 2.0 of cms in cms module constraint.

ps: Maybe the lock file must be updated as well before pushing a patch release.