### PR TITLE
allow core 2.0 and admin 4.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
 		"source": "https://github.com/cebe/luya-module-sitemap"
 	},
 	"require": {
-		"luyadev/luya-core" : "^1.0",
-		"luyadev/luya-module-cms": "^1.0 | ^2.0 | ^3.0",
+		"luyadev/luya-core" : "^1.0 | ^2.0",
+		"luyadev/luya-module-cms": "^1.0 | ^2.0 | ^3.0 | ^4.0",
 		"samdark/sitemap": "^2.0"
 	},
 	"require-dev" : {


### PR DESCRIPTION
Today we have released version 4.0 of admin/cms and 2.0 of the core library. Therefore those modules must be part of version constraint. Would be nice if you could merge and release quickly, otherwise quite a few projects are blocked :smile: 

thanks